### PR TITLE
Add in first datum

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ source = "github"
 
 4. Compile your project by running the command `aiken check` in your project directory.
 
+
 ## Usage
 
 To use the Aiken Assist Library in your project, import the desired modules in your code. For example:

--- a/aiken.toml
+++ b/aiken.toml
@@ -1,5 +1,5 @@
 name = "aiken-lang/assist"
-version = "0.1.3"
+version = "0.1.4"
 license = "Apache-2.0"
 description = "Aiken Assist Library"
 

--- a/lib/assist/find.ak
+++ b/lib/assist/find.ak
@@ -153,7 +153,7 @@ test find_output_by_addr() {
 
 /// Find the first output with an inline datum and return the data.
 /// If nothing is found then error. This works great for tx with a
-/// single output and datum. 
+/// single output and datum or where ordering is irrelevant.
 ///
 /// ```aiken
 /// find.first_output_datum(tx.outputs)
@@ -170,6 +170,15 @@ pub fn first_output_datum(outputs: List<Output>) -> Data {
     [] ->
       error @"No Datum Found"
   }
+}
+
+// can't test for errors yet
+test find_first_output_datum() {
+  let outputs =
+    fake_tx.test_tx().outputs
+  expect datum: ByteArray =
+    first_output_datum(outputs)
+  datum == fake_tx.test_datum
 }
 
 /// Find the first occurence of output datum by some address. If nothing is

--- a/lib/assist/find.ak
+++ b/lib/assist/find.ak
@@ -5,7 +5,8 @@
 use aiken/dict.{Dict}
 use aiken/list
 use aiken/transaction.{
-  Input, Output, OutputReference, Redeemer, ScriptPurpose, Spend, TransactionId,
+  InlineDatum, Input, Output, OutputReference, Redeemer, ScriptPurpose, Spend,
+  TransactionId,
 }
 use aiken/transaction/credential.{
   Address, Inline, StakeCredential, VerificationKeyCredential,
@@ -148,6 +149,27 @@ test find_output_by_addr() {
   let addr =
     addresses.create_address(#"acab", #"")
   output_by_addr(outputs, addr) == fake_tx.test_output()
+}
+
+/// Find the first output with an inline datum and return the data.
+/// If nothing is found then error. This works great for tx with a
+/// single output and datum. 
+///
+/// ```aiken
+/// find.first_output_datum(tx.outputs)
+/// ```
+pub fn first_output_datum(outputs: List<Output>) -> Data {
+  when outputs is {
+    [output, ..rest] ->
+      when output.datum is {
+        InlineDatum(outbound_datum) ->
+          outbound_datum
+        _ ->
+          first_output_datum(rest)
+      }
+    [] ->
+      error @"No Datum Found"
+  }
 }
 
 /// Find the first occurence of output datum by some address. If nothing is


### PR DESCRIPTION
Adding `find.first_output_datum` for finding the first occurrence of an inline datum from the outputs.