### PR TITLE
Add two new public methods to "find" module & refactorings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ artifacts/
 # Aiken's project working directory
 build/
 plutus.json
+# VSCode files & directory
+.vscode/
+*.code-workspace

--- a/lib/assist/find.ak
+++ b/lib/assist/find.ak
@@ -6,12 +6,14 @@ use aiken/dict.{Dict}
 use aiken/list
 use aiken/transaction.{
   InlineDatum, Input, Output, OutputReference, Redeemer, ScriptPurpose, Spend,
-  TransactionId,
+  TransactionId
 }
 use aiken/transaction/credential.{Address, StakeCredential}
+use aiken/transaction/value.{Value}
 use assist/addresses
 use assist/credentials
 use assist/data
+use assist/values
 // for testing only
 use tests/fake_tx
 
@@ -201,6 +203,73 @@ test find_output_datum_by_addr() {
   expect datum: ByteArray =
     output_datum_by_addr(outputs, addr)
   datum == fake_tx.test_datum
+}
+
+
+/// Return the first occurrence of an output that contains at least some specific
+/// value at some address. If nothing is found then error. This function
+/// does not search for an exact UTxO match.
+///
+/// ```aiken
+/// find.output_by_addr_value(tx.outputs, wallet_addr, just_token_value)
+/// ```
+pub fn output_by_addr_value(
+  outputs: List<Output>,
+  addr: Address,
+  value: Value,
+) -> Output {
+  when outputs is {
+    [output, ..rest] ->
+      if output.address == addr && values.contains(value, output.value) {
+        output
+      } else {
+        output_by_addr_value(rest, addr, value)
+      }
+    // nothing was found
+    [] -> 
+      error @"No Output found"
+  }
+}
+
+// can't test for errors yet
+test find_output_by_addr_value() {
+  let outputs =
+    fake_tx.test_tx().outputs
+  let addr =
+    addresses.create_address(#"acab", #"")
+  let value = 
+    value.from_asset(#"acab", #"beef", 40)
+  output_by_addr_value(outputs, addr, value) == fake_tx.test_output()
+}
+
+/// Return the first occurrence of an output that contains at least some specific
+/// value. If nothing is found then error. This function
+/// does not search for an exact UTxO match.
+///
+/// ```aiken
+/// find.output_by_value(tx.outputs, just_token_value)
+/// ```
+pub fn output_by_value(outputs: List<Output>, value: Value) -> Output {
+  when outputs is {
+    [output, ..rest] ->
+      if values.contains(value, output.value) {
+        output
+      } else {
+        output_by_value(rest, value)
+      }
+    // nothing was found
+    [] -> 
+      error @"No Output found"
+  }
+}
+
+// can't test for errors yet
+test find_output_by_value() {
+  let outputs =
+    fake_tx.test_tx().outputs
+  let value = 
+    value.from_asset(#"acab", #"beef", 10)
+  output_by_value(outputs, value) == fake_tx.test_output()
 }
 
 /// Find the staking reward amount in loveace for some stake credential.

--- a/lib/assist/payout.ak
+++ b/lib/assist/payout.ak
@@ -6,6 +6,7 @@ use aiken/transaction.{Output}
 use aiken/transaction/credential.{Address}
 use aiken/transaction/value.{AssetName, PolicyId, Value}
 use assist/addresses
+use assist/values
 // for testing only
 use tests/fake_tx
 
@@ -66,16 +67,13 @@ pub fn at_least(
   payout_value: Value,
   outputs: List<Output>,
 ) -> Bool {
-  let flattened_value =
-    value.flatten(payout_value)
   when outputs is {
     [output, ..rest] ->
       if
-      output.address == payout_address && check_all_assets(
-        output.value,
-        flattened_value,
-      ) == True{
-      
+      output.address == payout_address && values.contains(
+        payout_value,
+        output.value
+      ){
         True
       } else {
         at_least(payout_address, payout_value, rest)
@@ -83,24 +81,6 @@ pub fn at_least(
     // nothing was found
     [] ->
       False
-  }
-}
-
-// given a list of tokens check if at least the quantity is in the value.
-fn check_all_assets(
-  out_value: Value,
-  flattened_value: List<(PolicyId, AssetName, Int)>,
-) -> Bool {
-  when flattened_value is {
-    [(policy, token_name, quantity), ..rest] ->
-      if value.quantity_of(out_value, policy, token_name) >= quantity {
-        check_all_assets(out_value, rest)
-      } else {
-        False
-      }
-    // All the tokens exist
-    [] ->
-      True
   }
 }
 

--- a/lib/assist/payout.ak
+++ b/lib/assist/payout.ak
@@ -4,7 +4,7 @@
 
 use aiken/transaction.{Output}
 use aiken/transaction/credential.{Address}
-use aiken/transaction/value.{AssetName, PolicyId, Value}
+use aiken/transaction/value.{Value}
 use assist/addresses
 use assist/values
 // for testing only


### PR DESCRIPTION
1. Add two new public methods to "find" module - `output_by_addr_value, output_by_value`
2.  Remove private fn `check_all_assets` and replace it with identical public fn `values.contains` 