### PR TITLE
Change datum extraction

### DIFF
--- a/aiken.lock
+++ b/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1699477005, nanos_since_epoch = 235484194 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1702264066, nanos_since_epoch = 29603931 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/lib/assist/data.ak
+++ b/lib/assist/data.ak
@@ -129,3 +129,30 @@ pub fn output_datum_by_hash(
     _ -> fail @"No Output Datum"
   }
 }
+
+test find_output_datum_hash() {
+  let output = fake_tx.test_output_with_datum_hash()
+  let datums =
+    dict.new()
+      |> dict.insert(
+           key: fake_tx.test_datum,
+           value: builtin.i_data(1),
+           compare: bytearray.compare,
+         )
+  expect datum: Int = output_datum_by_hash(output, datums)
+  datum == 1
+}
+
+test cant_find_output_datum_hash() fail {
+  let output = fake_tx.test_output_with_datum_hash()
+  let datums =
+    dict.new()
+      |> dict.insert(
+           key: #"acab",
+           value: builtin.i_data(1),
+           compare: bytearray.compare,
+         )
+  expect datum: Int = output_datum_by_hash(output, datums)
+  // this will fail
+  datum == 1
+}

--- a/lib/assist/data.ak
+++ b/lib/assist/data.ak
@@ -2,7 +2,11 @@
 //// datum found in either an input or output.
 ////
 
-use aiken/transaction.{InlineDatum, Input, Output}
+use aiken/builtin
+use aiken/bytearray
+use aiken/dict.{Dict}
+use aiken/hash.{Blake2b_256, Hash}
+use aiken/transaction.{DatumHash, InlineDatum, Input, Output}
 // for testing only
 use tests/fake_tx
 
@@ -32,8 +36,56 @@ test cant_find_input_datum() fail {
   datum == fake_tx.test_datum
 }
 
+/// Find the datum data on a input by the datum hash or error. The
+/// data is assumed to be embedded data and must be referenced by
+/// its hash.
+///
+/// ```aiken
+/// expect datum: Datum = data.input_datum_by_hash(this_input, these_datums)
+/// ```
+pub fn input_datum_by_hash(
+  possible_input: Input,
+  datums: Dict<Hash<Blake2b_256, Data>, Data>,
+) -> Data {
+  when possible_input.output.datum is {
+    DatumHash(inbound_datum_hash) ->
+      when dict.get(datums, inbound_datum_hash) is {
+        Some(inbound_datum) -> inbound_datum
+        _ -> fail @"No Datum Attached"
+      }
+    _ -> fail @"No Input Datum"
+  }
+}
+
+test find_input_datum_hash() {
+  let input = fake_tx.test_input_with_datum_hash()
+  let datums =
+    dict.new()
+      |> dict.insert(
+           key: fake_tx.test_datum,
+           value: builtin.i_data(1),
+           compare: bytearray.compare,
+         )
+  expect datum: Int = input_datum_by_hash(input, datums)
+  datum == 1
+}
+
+test cant_find_input_datum_hash() fail {
+  let input = fake_tx.test_input_with_datum_hash()
+  let datums =
+    dict.new()
+      |> dict.insert(
+           key: #"acab",
+           value: builtin.i_data(1),
+           compare: bytearray.compare,
+         )
+  expect datum: Int = input_datum_by_hash(input, datums)
+  // this will fail
+  datum == 1
+}
+
 /// Find the datum data on an output or error. The data is assumed
-/// to be an inline datum.
+/// to be an inline datum first then it will seek the datum hash.
 ///
 /// ```aiken
 /// expect datum: Datum = data.output_datum(that_output)

--- a/lib/assist/data.ak
+++ b/lib/assist/data.ak
@@ -51,7 +51,7 @@ pub fn input_datum_by_hash(
     DatumHash(inbound_datum_hash) ->
       when dict.get(datums, inbound_datum_hash) is {
         Some(inbound_datum) -> inbound_datum
-        _ -> fail @"No Datum Attached"
+        _ -> fail @"No Input Datum Attached"
       }
     _ -> fail @"No Input Datum"
   }
@@ -85,7 +85,7 @@ test cant_find_input_datum_hash() fail {
 }
 
 /// Find the datum data on an output or error. The data is assumed
-/// to be an inline datum first then it will seek the datum hash.
+/// to be an inline datum.
 ///
 /// ```aiken
 /// expect datum: Datum = data.output_datum(that_output)
@@ -108,4 +108,24 @@ test cant_find_output_datum() fail {
   expect datum: ByteArray = output_datum(output)
   // this will fail
   datum == fake_tx.test_datum
+}
+
+/// Find the datum data on an output or error. The data is assumed
+/// to be embedded.
+///
+/// ```aiken
+/// expect datum: Datum = data.output_datum_by_hash(that_output, these_datums)
+/// ```
+pub fn output_datum_by_hash(
+  possible_output: Output,
+  datums: Dict<Hash<Blake2b_256, Data>, Data>,
+) -> Data {
+  when possible_output.datum is {
+    DatumHash(outbound_datum_hash) ->
+      when dict.get(datums, outbound_datum_hash) is {
+        Some(outbound_datum) -> outbound_datum
+        _ -> fail @"No Output Datum Attached"
+      }
+    _ -> fail @"No Output Datum"
+  }
 }

--- a/lib/tests/fake_tx.ak
+++ b/lib/tests/fake_tx.ak
@@ -124,6 +124,18 @@ pub fn test_output() -> Output {
   output
 }
 
+// A fake output with a datum hash used for testing.
+pub fn test_output_with_datum_hash() -> Output {
+  let output =
+    Output {
+      address: addresses.create_address(#"acab", #""),
+      value: value.from_asset(#"acab", #"beef", 40),
+      datum: DatumHash(test_datum),
+      reference_script: None,
+    }
+  output
+}
+
 /// A fake output without datum used for testing.
 pub fn test_bad_output() -> Output {
   let output =

--- a/lib/tests/fake_tx.ak
+++ b/lib/tests/fake_tx.ak
@@ -5,8 +5,8 @@ use aiken/dict
 use aiken/interval.{Interval, IntervalBound, NegativeInfinity, PositiveInfinity}
 use aiken/list
 use aiken/transaction.{
-  InlineDatum, Input, NoDatum, Output, OutputReference, Spend, Transaction,
-  TransactionId,
+  DatumHash, InlineDatum, Input, NoDatum, Output, OutputReference, Spend,
+  Transaction, TransactionId,
 }
 use aiken/transaction/credential.{StakeCredential}
 use aiken/transaction/value
@@ -70,6 +70,24 @@ pub fn test_input() -> Input {
         address: addresses.create_address(#"acab", #""),
         value: value.from_lovelace(100),
         datum: InlineDatum(test_datum),
+        reference_script: None,
+      },
+    }
+  input
+}
+
+/// A fake input with a datum hash.
+pub fn test_input_with_datum_hash() {
+  let input =
+    Input {
+      output_reference: OutputReference {
+        transaction_id: TransactionId { hash: #"acab" },
+        output_index: 0,
+      },
+      output: Output {
+        address: addresses.create_address(#"acab", #""),
+        value: value.from_lovelace(100),
+        datum: DatumHash(test_datum),
         reference_script: None,
       },
     }


### PR DESCRIPTION
An input and output datum can now be found by just the datum hash. The previous functions are kept the same for backward capability. The design is to pick one or the other and not both for this current implementation as combing both will break all old versions of assist.