### PR TITLE
types are now there own thing with specialized functions

### DIFF
--- a/lib/assist/addresses.ak
+++ b/lib/assist/addresses.ak
@@ -7,7 +7,8 @@ use aiken/bytearray
 use aiken/transaction/credential.{
   Address, Inline, ScriptCredential, VerificationKeyCredential,
 }
-use assist/types.{PublicKeyHash, ValidatorHash, Wallet}
+use assist/types/hashes.{PublicKeyHash, ValidatorHash}
+use assist/types/wallet.{Wallet}
 
 /// Creates an address from the wallet type.
 ///

--- a/lib/assist/certificates.ak
+++ b/lib/assist/certificates.ak
@@ -5,7 +5,7 @@
 use aiken/transaction/certificate.{Certificate, CredentialDelegation}
 use aiken/transaction/credential.{PoolId}
 use assist/credentials
-use assist/types.{ValidatorHash}
+use assist/types/hashes.{ValidatorHash}
 
 /// Creates a credential delegation for changing the location of the stake.
 /// This certificate can be used to check if stake is being delegated to

--- a/lib/assist/credentials.ak
+++ b/lib/assist/credentials.ak
@@ -5,7 +5,7 @@
 use aiken/transaction/credential.{
   Credential, Inline, Referenced, ScriptCredential,
 }
-use assist/types.{ValidatorHash}
+use assist/types/hashes.{ValidatorHash}
 
 /// Creates a stake credential from the hex encoding of a stake key.
 /// This can be used to find the reward amount from the withdrawals 

--- a/lib/assist/signing.ak
+++ b/lib/assist/signing.ak
@@ -3,7 +3,7 @@
 ////
 
 use aiken/list
-use assist/types.{PublicKeyHash}
+use assist/types/hashes.{PublicKeyHash}
 // for testing only
 use tests/fake_tx
 

--- a/lib/assist/tx.ak
+++ b/lib/assist/tx.ak
@@ -7,7 +7,7 @@ use aiken/transaction.{Input, OutputReference}
 use aiken/transaction/credential
 use aiken/transaction/value.{AssetName, PolicyId}
 use assist/std
-use assist/types.{ValidatorHash}
+use assist/types/hashes.{ValidatorHash}
 use tests/fake_tx
 
 /// Check if a specific input by output reference is being spent. This is useful

--- a/lib/assist/types/cip68.ak
+++ b/lib/assist/types/cip68.ak
@@ -1,0 +1,8 @@
+use aiken/dict.{Dict}
+
+/// The generic CIP68 metadatum type as defined in the CIP at
+/// https://cips.cardano.org/cips/cip68/.
+pub type CIP68 {
+  metadata: Dict<Data, Data>,
+  version: Int,
+}

--- a/lib/assist/types/hashes.ak
+++ b/lib/assist/types/hashes.ak
@@ -1,11 +1,6 @@
-//// General data types for smart contracts.
-////
-
-use aiken/dict.{Dict}
 use aiken/hash.{Blake2b_224, Blake2b_256, Hash}
 use aiken/transaction.{Transaction}
 use aiken/transaction/credential.{Script, VerificationKey}
-use aiken/transaction/value.{AssetName, PolicyId}
 
 /// The public key hash, vkey, of an wallet address. Expected to be length 56 and
 /// is network agnostic. This is a non-smart contract hash. 
@@ -20,23 +15,3 @@ pub type ValidatorHash =
 /// The transaction hash. Its the blake2b 256 of a tx body.
 pub type TxHash =
   Hash<Blake2b_256, Transaction>
-
-/// A wallet type for a non-smart contract address.
-pub type Wallet {
-  pkh: PublicKeyHash,
-  sc: PublicKeyHash,
-}
-
-/// A token type for a safe single policy id and asset name value.
-pub type Token {
-  pid: PolicyId,
-  tkn: AssetName,
-  amt: Int,
-}
-
-/// The generic CIP68 metadatum type as defined in the CIP at
-/// https://cips.cardano.org/cips/cip68/.
-pub type CIP68 {
-  metadata: Dict<Data, Data>,
-  version: Int,
-}

--- a/lib/assist/types/moment.ak
+++ b/lib/assist/types/moment.ak
@@ -1,0 +1,179 @@
+use aiken/interval.{
+  Finite, Interval, IntervalBound, NegativeInfinity, PositiveInfinity,
+}
+use aiken/transaction.{ValidityRange}
+
+/// A finite moment of time represented as simple start and end integers.
+pub type Moment {
+  start: Int,
+  end: Int,
+}
+
+/// Check if a moment data structure is logical. 
+///
+/// ```aiken
+/// moment.is_logical(datum.moment)
+/// ```
+pub fn is_logical(m: Moment) -> Bool {
+  and {
+    m.end >= m.start,
+    m.start >= 0,
+    m.end >= 0,
+  }
+}
+
+test an_empty_moment() {
+  let m: Moment = Moment { start: 0, end: 0 }
+  is_logical(m) == True
+}
+
+test a_nonvalid_moment() {
+  let m: Moment = Moment { start: 10, end: 0 }
+  is_logical(m) == False
+}
+
+test a_valid_moment() {
+  let m: Moment = Moment { start: 10, end: 11230 }
+  is_logical(m) == True
+}
+
+/// Check if a moment is contained within some validity range of a tx.
+/// This assumes inclusivity.
+///
+/// ```aiken
+/// moment.is_contained(datum.moment, this_tx.validity_range)
+/// ```
+pub fn is_contained(m: Moment, vr: ValidityRange) -> Bool {
+  when vr.lower_bound.bound_type is {
+    // must be finite
+    NegativeInfinity -> False
+    // get the lower bound int
+    Finite(lower_bound) ->
+      when vr.upper_bound.bound_type is {
+        // must be finite
+        NegativeInfinity -> False
+        // get the upper bound int
+        Finite(upper_bound) -> and {
+            // the lower bound is less than or equal the start of the momement
+            lower_bound <= m.start,
+            // the upper bound is greater or equal to the end of the momment
+            upper_bound >= m.end,
+          }
+        // must be finite
+        PositiveInfinity -> False
+      }
+    // must be finite
+    PositiveInfinity -> False
+  }
+}
+
+test an_empty_moment_is_not_contained_in_infinty() {
+  let vr: ValidityRange =
+    Interval {
+      lower_bound: IntervalBound {
+        bound_type: NegativeInfinity,
+        is_inclusive: True,
+      },
+      upper_bound: IntervalBound {
+        bound_type: PositiveInfinity,
+        is_inclusive: True,
+      },
+    }
+  let m: Moment = Moment { start: 0, end: 0 }
+  // the bounds can not be infinite
+  is_contained(m, vr) == False
+}
+
+test an_empty_moment_is_contained_in_a_finite_range() {
+  let vr: ValidityRange =
+    Interval {
+      lower_bound: IntervalBound { bound_type: Finite(-10), is_inclusive: True },
+      upper_bound: IntervalBound { bound_type: Finite(10), is_inclusive: True },
+    }
+  let m: Moment = Moment { start: 0, end: 0 }
+  is_contained(m, vr) == True
+}
+
+test a_moment_is_contained_in_the_validity_range() {
+  let vr: ValidityRange =
+    Interval {
+      lower_bound: IntervalBound { bound_type: Finite(0), is_inclusive: True },
+      upper_bound: IntervalBound { bound_type: Finite(10), is_inclusive: True },
+    }
+  let m: Moment = Moment { start: 0, end: 10 }
+  is_contained(m, vr) == True
+}
+
+/// Check if a validity range of a tx is after a moment.
+/// This assumes exclusivity.
+///
+/// ```aiken
+/// moment.is_after(datum.moment, this_tx.validity_range)
+/// ```
+pub fn is_after(m: Moment, vr: ValidityRange) -> Bool {
+  when vr.lower_bound.bound_type is {
+    // must be finite
+    NegativeInfinity -> False
+    // get the lower bound int
+    Finite(lower_bound) -> m.end < lower_bound
+    // must be finite
+    PositiveInfinity -> False
+  }
+}
+
+test a_validity_range_is_after_a_moment() {
+  let vr: ValidityRange =
+    Interval {
+      lower_bound: IntervalBound { bound_type: Finite(5), is_inclusive: True },
+      upper_bound: IntervalBound { bound_type: Finite(10), is_inclusive: True },
+    }
+  let m: Moment = Moment { start: 1, end: 4 }
+  is_after(m, vr) == True
+}
+
+test a_validity_range_is_not_after_a_moment() {
+  let vr: ValidityRange =
+    Interval {
+      lower_bound: IntervalBound { bound_type: Finite(0), is_inclusive: True },
+      upper_bound: IntervalBound { bound_type: Finite(10), is_inclusive: True },
+    }
+  let m: Moment = Moment { start: 1, end: 13 }
+  is_after(m, vr) == False
+}
+
+/// Check if a validity range of a tx is before a moment.
+/// This assumes exclusivity.
+///
+/// ```aiken
+/// moment.is_before(datum.moment, this_tx.validity_range)
+/// ```
+pub fn is_before(m: Moment, vr: ValidityRange) -> Bool {
+  when vr.upper_bound.bound_type is {
+    // must be finite
+    NegativeInfinity -> False
+    // get the upper bound int
+    Finite(upper_bound) -> upper_bound < m.start
+    // must be finite
+    PositiveInfinity -> False
+  }
+}
+
+test a_validity_range_is_before_a_moment() {
+  let vr: ValidityRange =
+    Interval {
+      lower_bound: IntervalBound { bound_type: Finite(0), is_inclusive: True },
+      upper_bound: IntervalBound { bound_type: Finite(10), is_inclusive: True },
+    }
+  let m: Moment = Moment { start: 11, end: 13 }
+  is_before(m, vr) == True
+}
+
+test a_validity_range_is_not_before_a_moment() {
+  let vr: ValidityRange =
+    Interval {
+      lower_bound: IntervalBound { bound_type: Finite(10), is_inclusive: True },
+      upper_bound: IntervalBound { bound_type: Finite(12), is_inclusive: True },
+    }
+  let m: Moment = Moment { start: 11, end: 13 }
+  is_before(m, vr) == False
+}

--- a/lib/assist/types/token.ak
+++ b/lib/assist/types/token.ak
@@ -1,0 +1,80 @@
+use aiken/transaction/value.{AssetName, PolicyId, Value}
+
+/// A token type for a safe single policy id and asset name value.
+pub type Token {
+  pid: PolicyId,
+  tkn: AssetName,
+  amt: Int,
+}
+
+/// A tokens type for a safe value as a list of Tokens.
+pub type Tokens =
+  List<Token>
+
+/// Add a Token type to a Value type. This should be a very safe way to
+/// increment a value on a UTxO. The other option is having the redeemer be 
+/// the general Value type and potentially allow badly formed values to be used.
+///
+/// ```aiken
+/// add_token_to_value(token, this_value)
+/// ```
+pub fn add_token_to_value(the_value: Value, token: Token) -> Value {
+  value.add(the_value, token.pid, token.tkn, token.amt)
+}
+
+test add_empty_token_to_value() {
+  let zero: Value = value.zero()
+  let token: Token = Token { pid: #"", tkn: #"", amt: 0 }
+  add_token_to_value(zero, token) == zero
+}
+
+test add_ada_token_to_value() {
+  let zero: Value = value.zero()
+  let token: Token = Token { pid: #"", tkn: #"", amt: 10 }
+  add_token_to_value(zero, token) == value.from_lovelace(10)
+}
+
+test add_and_subtract_token_to_value() {
+  let zero: Value = value.zero()
+  let token1: Token = Token { pid: #"", tkn: #"", amt: 10 }
+  let token2: Token = Token { pid: #"", tkn: #"", amt: -10 }
+  let expected: Value =
+    add_token_to_value(zero, token1) |> add_token_to_value(token2)
+  expected == zero
+}
+
+/// Add a list of Token types to a Value type. This should be a very safe way to
+/// increment a value on a UTxO. The other option is having the redeemer be 
+/// the general Value type and potentially allow badly formed values to be used.
+///
+/// ```aiken
+/// add_tokens_to_value(redeemer.tokens, this_value)
+/// ```
+fn add_tokens_to_value(the_value: Value, tokens: Tokens) -> Value {
+  when tokens is {
+    // take a token and add it to the value
+    [tkn, ..rest] ->
+      add_token_to_value(the_value, tkn) |> add_tokens_to_value(rest)
+    // return the value
+    [] -> the_value
+  }
+}
+
+test add_empty_tokens_to_value() {
+  let zero: Value = value.zero()
+  let token: Token = Token { pid: #"", tkn: #"", amt: 0 }
+  add_tokens_to_value(zero, [token, token, token]) == zero
+}
+
+test add_ada_tokens_to_value() {
+  let zero: Value = value.zero()
+  let token: Token = Token { pid: #"", tkn: #"", amt: 10 }
+  add_tokens_to_value(zero, [token, token, token]) == value.from_lovelace(30)
+}
+
+test add_and_subtract_tokens_to_value() {
+  let zero: Value = value.zero()
+  let token1: Token = Token { pid: #"", tkn: #"", amt: 10 }
+  let token2: Token = Token { pid: #"", tkn: #"", amt: -10 }
+  add_tokens_to_value(zero, [token1, token2]) == zero
+}

--- a/lib/assist/types/wallet.ak
+++ b/lib/assist/types/wallet.ak
@@ -1,0 +1,7 @@
+use assist/types/hashes.{PublicKeyHash}
+
+/// A wallet type for a non-smart contract address.
+pub type Wallet {
+  pkh: PublicKeyHash,
+  sc: PublicKeyHash,
+}

--- a/lib/assist/values.ak
+++ b/lib/assist/values.ak
@@ -9,7 +9,8 @@ use aiken/list
 use aiken/string
 use aiken/transaction/value.{AssetName, PolicyId, Value}
 use assist/prefixes
-use assist/types.{Token, TxHash}
+use assist/types/hashes.{TxHash}
+use assist/types/token.{Token}
 
 /// Creates a Value type from a token type.
 pub fn from_token(token: Token) -> Value {


### PR DESCRIPTION
This should remove any name conflicts with using assist/types and should allow for more expansive general types to be added to the library.