### PR TITLE
added in wallets and added a function to cip68 while at it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # v0.x.y
 
+- Added the `Wallets` type and `to_vks`  to the wallet submodule.
+- Added `get` and `version` to the cip68 types submodule.
+
 # v0.4.4
 
 - Documentation is now hosted at logicalmechanism.io

--- a/lib/assist/types/cip68.ak
+++ b/lib/assist/types/cip68.ak
@@ -6,3 +6,25 @@ pub type CIP68 {
   metadata: Dict<Data, Data>,
   version: Int,
 }
+
+/// Attempt to find a data structure by a key inside the cip68 metadatum. If
+/// nothing is found then fail.
+///
+/// ```aiken
+/// cip68.get(datum, some_key)
+/// ```
+pub fn get(cip68: CIP68, key: Data) -> Data {
+  when dict.get(cip68.metadata, key) is {
+    Some(thing) -> thing
+    None -> fail @"Data Structure Not Found"
+  }
+}
+
+/// Return the version of the metadata.
+///
+/// ```aiken
+/// datum |> cip68.version
+/// ```
+pub fn version(metadata: CIP68) -> Int {
+  metadata.version
+}

--- a/lib/assist/types/wallet.ak
+++ b/lib/assist/types/wallet.ak
@@ -1,10 +1,53 @@
 use aiken/bytearray
+use aiken/list
 use assist/types/hashes.{PublicKeyHash}
 
 /// A wallet type for a non-smart contract address.
 pub type Wallet {
   pkh: PublicKeyHash,
   sc: PublicKeyHash,
+}
+
+/// A list of wallets for non-smart contract addresses.
+pub type Wallets =
+  List<Wallet>
+
+/// Convert a list of wallets into a list of public key hashes. This is useful
+/// when doing multisig validation. The output order respects the input order.
+///
+/// ```aiken
+/// wallet.to_vks(datum.wallets)
+/// ```
+pub fn to_vks(wallets: Wallets) -> List<PublicKeyHash> {
+  list.map(wallets, fn(w) { w.pkh })
+}
+
+test empty_to_vks() {
+  to_vks([]) == []
+}
+
+test single_to_vks() {
+  let w: Wallet =
+    Wallet {
+      pkh: #"abcdef0123456789abcdef0123456789abcdef0123456789abcdef01",
+      sc: #"",
+    }
+  to_vks([w]) == [#"abcdef0123456789abcdef0123456789abcdef0123456789abcdef01"]
+}
+
+test multiple_to_vks() {
+  let w: Wallet =
+    Wallet {
+      pkh: #"abcdef0123456789abcdef0123456789abcdef0123456789abcdef01",
+      sc: #"",
+    }
+  let expected: List<PublicKeyHash> =
+    [
+      #"abcdef0123456789abcdef0123456789abcdef0123456789abcdef01",
+      #"abcdef0123456789abcdef0123456789abcdef0123456789abcdef01",
+      #"abcdef0123456789abcdef0123456789abcdef0123456789abcdef01",
+    ]
+  to_vks([w, w, w]) == expected
 }
 
 /// Check if a wallet has a bad form and needs to be bypassed.


### PR DESCRIPTION
Adding the `Wallets` type with a `to_vks` function. The cip68 got a `get` and `version` function. These experimental functions may not remain forever.