### PR TITLE
cip68 doesn't use a dict anymore; intermediate fix until aiken 1.0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # v0.x.y
 
 - Updated to Aiken 1.0.26
+- Updated to stdlib 1.8.0
+- Update CIP68 Data Structure
+- Changed cip68.get, it loops a list instead of doing a dict.get
 
 # v0.4.6
 

--- a/aiken.toml
+++ b/aiken.toml
@@ -10,5 +10,5 @@ platform = "github"
 
 [[dependencies]]
 name = "aiken-lang/stdlib"
-version = "1.7.0"
+version = "1.8.0"
 source = "github"

--- a/lib/assist/types/cip68.ak
+++ b/lib/assist/types/cip68.ak
@@ -1,4 +1,4 @@
-use aiken/dict.{Dict}
+use aiken/builtin
 
 /// (100) Reference Token Prefix
 /// https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0068/#222-nft-standard
@@ -19,7 +19,7 @@ pub const prefix_444: ByteArray = #"001bc280"
 /// The generic CIP68 metadatum type as defined in the CIP at
 /// https://cips.cardano.org/cips/cip68/.
 pub type CIP68 {
-  metadata: Dict<Data, Data>,
+  metadata: List<(Data, Data)>,
   version: Int,
 }
 
@@ -27,19 +27,28 @@ pub type CIP68 {
 /// nothing is found then fail.
 ///
 /// ```aiken
-/// cip68.get(datum, some_key)
+/// cip68.get(metadatum, some_key)
 /// ```
 pub fn get(cip68: CIP68, key: Data) -> Data {
-  when dict.get(cip68.metadata, key) is {
-    Some(thing) -> thing
-    None -> fail @"Data Structure Not Found"
+  do_get(cip68.metadata, key)
+}
+
+fn do_get(cip68: List<(Data, Data)>, key: Data) -> Data {
+  when cip68 is {
+    [] -> fail @"Data Structure Not Found"
+    [d, ..ds] ->
+      if builtin.fst_pair(d) == key {
+        builtin.snd_pair(d)
+      } else {
+        do_get(ds, key)
+      }
   }
 }
 
 /// Return the version of the metadata.
 ///
 /// ```aiken
-/// datum |> cip68.version
+/// metadatum |> cip68.version
 /// ```
 pub fn version(metadata: CIP68) -> Int {
   metadata.version


### PR DESCRIPTION
The cip68 was defined using a Dict type. As of 1.0.26 this type should not be used. It is now replaced with a list of tuples. This is only applicable for 1.0.26 as in the .27 release this will need to be updated again into a list of pairs of values.